### PR TITLE
按运维和运营的要求将开发网底层版本更新为1.0.0，保持之前状态不变

### DIFF
--- a/docs/成为开发网验证节点.md
+++ b/docs/成为开发网验证节点.md
@@ -62,8 +62,8 @@ ntpq -4c rv | grep leap_none
 #### Install PlatON
 
 ```bash
-sudo wget https://download.platon.network/platon/devnet/platon/1.1.0/platon -P /usr/bin
-sudo wget https://download.platon.network/platon/devnet/platon/1.1.0/platonkey -P /usr/bin
+sudo wget https://download.platon.network/platon/devnet/platon/1.0.0/platon -P /usr/bin
+sudo wget https://download.platon.network/platon/devnet/platon/1.0.0/platonkey -P /usr/bin
 sudo chmod +x /usr/bin/platon  /usr/bin/platonkey
 platon version
 ```
@@ -135,8 +135,8 @@ The development network provides a development test environment for the develope
 
 #### Develop network related resources
 
-> - platon：https://download.platon.network/platon/devnet/platon/1.1.0/platon
-> - platonkey：https://download.platon.network/platon/devnet/platon/1.1.0/platonkey
+> - platon：https://download.platon.network/platon/devnet/platon/1.0.0/platon
+> - platonkey：https://download.platon.network/platon/devnet/platon/1.0.0/platonkey
 >
 > - mtool windows：https://download.platon.network/platon/devnet/mtool/windows/1.0.1/platon_mtool.exe
 >

--- a/docs/接入开发网.md
+++ b/docs/接入开发网.md
@@ -16,7 +16,7 @@ http://47.241.98.219:6789 and ws://47.241.98.219:6790
 #### Access method 1:  Connect to the DevNet via the local PlatON node
 on the ubuntu 18.04 server, download and install the PlatON binary with the following command:
 ```bash
-sudo wget https://download.platon.network/platon/platon/1.1.0/platon -P /usr/bin    
+sudo wget https://download.platon.network/platon/platon/1.0.0/platon -P /usr/bin    
 ```
 Connect to the development network by.
 ```bash

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/成为开发网验证节点.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/成为开发网验证节点.md
@@ -57,8 +57,8 @@ ntpq -4c rv | grep leap_none
 #### 安装 PlatON
 
 ```bash
-sudo wget https://download.platon.network/platon/devnet/platon/1.1.0/platon -O /usr/bin/platon
-sudo wget https://download.platon.network/platon/devnet/platon/1.1.0/platonkey -O /usr/bin/platonkey
+sudo wget https://download.platon.network/platon/devnet/platon/1.0.0/platon -O /usr/bin/platon
+sudo wget https://download.platon.network/platon/devnet/platon/1.0.0/platonkey -O /usr/bin/platonkey
 sudo chmod +x /usr/bin/platon /usr/bin/platonkey
 platon version
 ```
@@ -132,8 +132,8 @@ cd ~/platon-node
 
 #### 开发网络相关资源
 
->- platon：https://download.platon.network/platon/devnet/platon/1.1.0/platon
->- platonkey：https://download.platon.network/platon/devnet/platon/1.1.0/platonkey
+>- platon：https://download.platon.network/platon/devnet/platon/1.0.0/platon
+>- platonkey：https://download.platon.network/platon/devnet/platon/1.0.0/platonkey
 >- mtool windows：https://download.platon.network/platon/devnet/mtool/windows/1.0.1/platon_mtool.exe
 >- mtool linux：https://download.platon.network/platon/devnet/mtool/linux/1.0.1/platon_mtool.zip
 >

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/接入开发网.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/接入开发网.md
@@ -18,7 +18,7 @@ http://47.241.98.219:6789 以及 ws://47.241.98.219:6790
 
 在ubuntu18.04服务器上，通过以下命令下载并安装PlatON二进制文件:
 ```
-sudo wget https://download.platon.network/platon/devnet/platon/1.1.0/platon -P /usr/bin    
+sudo wget https://download.platon.network/platon/devnet/platon/1.0.0/platon -P /usr/bin    
 ```
 通过以下方式连接入开发网：
 ```


### PR DESCRIPTION
1、开发者文档开发网接入部分暂不修改，有节点接入需求的单独沟通支持，对于通过RPC/WS方式调用接入开发网调测的社区开发者无影响；
2、等主网升级完成后，进行开发网重置部署，提前发布社区公示，以避免影响社区开发，重置部署时间暂定9月1日；