### PR TITLE
开发者文档更新mtool 1.1.0版本

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -35,7 +35,7 @@ The LatticeX Foundation has now opened the [Grants program](https://latticex.fou
     <tr>
         <td><img alt="" src="/docs/img/MTool_logo.svg" /></td>
         <td>
-            <p className="color"><a target="_blank" href="https://download.platon.network/platon/mtool/windows/1.0.0/platon_mtool.exe">PlatON MTool</a></p>
+            <p className="color"><a target="_blank" href="https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe">PlatON MTool</a></p>
             PlatON's Node Management Tool.
         </td>
     </tr>

--- a/docs/在线PlatON MTool使用手册.md
+++ b/docs/在线PlatON MTool使用手册.md
@@ -42,7 +42,7 @@ Double-click `C:\platon_mtool\unins000.exe` to uninstall all old versions of Pla
 
 **Step1. Download PlatON MTool installation package**
 
-On the online machine, copy the link https://download.platon.network/platon/mtool/windows/1.0.1/platon_mtool.exe  to the browser and download the PlatON MTool installation package.
+On the online machine, copy the link https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe  to the browser and download the PlatON MTool installation package.
 
 **Step2. Install PlatON MTool**
 
@@ -65,7 +65,7 @@ Proceed as follows:
 **Step1. Download PlatON MTool toolkit**
 
 ```bash
-wget https://download.platon.network/platon/mtool/linux/1.0.1/platon_mtool.zip
+wget https://download.platon.network/platon/mtool/linux/1.1.0/platon_mtool.zip
 ```
 
 **Step2. Extract the PlatON MTool toolkit**

--- a/docs/成为主网验证节点.md
+++ b/docs/成为主网验证节点.md
@@ -267,7 +267,7 @@ Proceed as follows:
 **Step1. Download PlatON MTool toolkit**
 
 ```bash
-wget https://download.platon.network/platon/mtool/linux/1.0.1/platon_mtool.zip
+wget https://download.platon.network/platon/mtool/linux/1.1.0/platon_mtool.zip
 ```
 
 **Step2. Extract the PlatON MTool toolkit**

--- a/docs/离线PlatON MTool使用手册.md
+++ b/docs/离线PlatON MTool使用手册.md
@@ -42,7 +42,7 @@ Double-click `C:\platon_mtool\unins000.exe` to uninstall all old versions of Pla
 
 **step1. Download the PlatON MTool installation package**
 
-On the online machine, copy the link <https://download.platon.network/platon/mtool/windows/1.0.1/platon_mtool.exe> to the browser to download the PlatON MTool installation package.
+On the online machine, copy the link <https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe> to the browser to download the PlatON MTool installation package.
 
 **step2. Install PlatON MTool**
 
@@ -66,7 +66,7 @@ Proceed as follows:
 **step1. Download PlatON MTool Toolkit**
 
 ``` bash
-wget https://download.platon.network/platon/mtool/linux/1.0.1/platon_mtool.zip
+wget https://download.platon.network/platon/mtool/linux/1.1.0/platon_mtool.zip
 ```
 
 **step2. Unzip PlatON MTool toolkit**

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/community.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/community.md
@@ -35,7 +35,7 @@ sidebar_label: 社区项目
     <tr>
         <td><img alt="" src="/docs/img/MTool_logo.svg" /></td>
         <td>
-            <p className="color"><a target="_blank" href="https://download.platon.network/platon/mtool/windows/1.0.0/platon_mtool.exe">PlatON MTool</a></p>
+            <p className="color"><a target="_blank" href="https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe">PlatON MTool</a></p>
             PlatON节点管理工具。
         </td>
     </tr>

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/在线PlatON MTool使用手册.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/在线PlatON MTool使用手册.md
@@ -41,7 +41,7 @@ platon_mtool --version
 
 **step1. 下载PlatON MTool安装包**
 
-在在线机器上，复制链接https://download.platon.network/platon/mtool/windows/1.0.1/platon_mtool.exe 到浏览器下载PlatON MTool安装包。
+在在线机器上，复制链接https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe 到浏览器下载PlatON MTool安装包。
 
 **step2. 安装PlatON MTool**
 
@@ -64,7 +64,7 @@ platon_mtool --version
 **step1. 下载PlatON MTool工具包**
 
 ``` bash
-wget https://download.platon.network/platon/mtool/linux/1.0.1/platon_mtool.zip
+wget https://download.platon.network/platon/mtool/linux/1.1.0/platon_mtool.zip
 ```
 
 **step2. 解压PlatON MTool工具包**

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/成为主网验证节点.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/成为主网验证节点.md
@@ -281,7 +281,7 @@ PlatON 是实行民主治理的区块链项目，验证节点由所有 LAT 持�
 **step1. 下载PlatON MTool工具包**
 
 ```bash
-wget https://download.platon.network/platon/mtool/linux/1.0.1/platon_mtool.zip
+wget https://download.platon.network/platon/mtool/linux/1.1.0/platon_mtool.zip
 ```
 
 **step2. 解压PlatON MTool工具包**

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/离线PlatON MTool使用手册.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/离线PlatON MTool使用手册.md
@@ -42,7 +42,7 @@ platon_mtool --version
 
 **step1. 下载PlatON MTool安装包**
 
-在在线机器上，复制链接<https://download.platon.network/platon/mtool/windows/1.0.1/platon_mtool.exe> 到浏览器下载PlatON MTool安装包。
+在在线机器上，复制链接<https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe> 到浏览器下载PlatON MTool安装包。
 
 **step2. 安装PlatON MTool**
 
@@ -65,7 +65,7 @@ platon_mtool --version
 **step1. 下载PlatON MTool工具包**
 
 ``` bash
-wget https://download.platon.network/platon/mtool/linux/1.0.1/platon_mtool.zip
+wget https://download.platon.network/platon/mtool/linux/1.1.0/platon_mtool.zip
 ```
 
 **step2. 解压PlatON MTool工具包**


### PR DESCRIPTION
开发者文档更新mtool 1.1.0版本，链接如下：
linux：https://download.platon.network/platon/mtool/linux/1.1.0/platon_mtool.zip
windows：https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe