### PR TITLE
community.md文档更新mtool 1.1.0版本

### DIFF
--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/community.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/community.md
@@ -35,7 +35,7 @@ sidebar_label: 社区项目
     <tr>
         <td><img alt="" src="/docs/img/MTool_logo.svg" /></td>
         <td>
-            <p className="color"><a target="_blank" href="https://download.platon.network/platon/mtool/windows/1.0.1/platon_mtool.exe">PlatON MTool</a></p>
+            <p className="color"><a target="_blank" href="https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe">PlatON MTool</a></p>
             PlatON节点管理工具。
         </td>
     </tr>


### PR DESCRIPTION
community.md文档更新mtool 1.1.0版本，链接如下：
windows：https://download.platon.network/platon/mtool/windows/1.1.0/platon_mtool.exe