### PR TITLE
platon::db::MultiIndex::find use error

### DIFF
--- a/docs/wasm合约API.md
+++ b/docs/wasm合约API.md
@@ -926,7 +926,7 @@ MultiIndex supports unique indexes and ordinary indexes. The unique index should
       IndexedBy<"index2"_n, IndexMemberFun<Member, uint8_t, &Member::Age,
                                           IndexType::NormalIndex>>>
       member_table;
-      auto vect_iter = member_table.find<"index2"_n>(uint8_t(10));
+      auto vect_iter = member_table.find<"index"_n>(std::string("use to find data"));
       member_table.erase(vect_iter[0]);
       ```
 
@@ -956,7 +956,7 @@ MultiIndex supports unique indexes and ordinary indexes. The unique index should
       IndexedBy<"index2"_n, IndexMemberFun<Member, uint8_t, &Member::Age,
                                             IndexType::NormalIndex>>>
       member_table;
-      auto vect_iter = member_table.find<"index2"_n>(uint8_t(10));
+      auto vect_iter = member_table.find<"index"_n>(std::string("use to find data"));
       ```
 
     * `template<Name::Raw TableName, typename T , typename... Indices> template<Name::Raw IndexName>auto platon::db::MultiIndex< TableName, T, Indices >::get_index()`


### PR DESCRIPTION
NormalIndex can not be used in platon::db::MultiIndex::find

see:    

template <Name::Raw IndexName, typename KEY>
  const_iterator find(const KEY &key) {
    static_assert(check_index_unique<IndexName>(),
                  "name provided is not the unique index within multi_index");
    const_iterator result = cend();
    hana::any_of(indices_, [&](auto &idx) {
      uint64_t index_name = static_cast<uint64_t>(IndexName);
      typedef typename decltype(+hana::at_c<0>(idx))::type IndexType;
      if (IndexType::index_name() == index_name) {
        if (has_index_db(static_cast<uint64_t>(TableName),
                         static_cast<uint64_t>(IndexName), key)) {
          uint64_t seq = get_index_db<KEY, uint64_t>(
              static_cast<uint64_t>(TableName),
              static_cast<uint64_t>(IndexName), key);
          auto item = get_item_ptr(seq);
          result.reset(item);
        }
        return true;
      }
      return false;
    });
    return result;
  }