### PR TITLE
更新开发网水龙头链接

### DIFF
--- a/docs/开发网水龙头.md
+++ b/docs/开发网水龙头.md
@@ -18,7 +18,7 @@ The test coins are worthless in real world. They can be used only  when you real
 
 2. Link of faucet, how to apply for test coins and the rules of application.
 
-Link to apply for test coins on DevNetwork of PlatON: https://faucet.platon.network/faucet/?id=39fa041c887f11eba4f000163e06ae15。
+Link to apply for test coins on DevNetwork of PlatON: https://faucet.platon.network/faucet/。
 
 Note:
 

--- a/docs/接入开发网.md
+++ b/docs/接入开发网.md
@@ -47,7 +47,7 @@ Not limited to the above language SDKs, you also have access through SDKs in oth
 
 ### **Step 2: Apply for DevNet Test Token**
 
-Click [faucet](https://faucet.platon.network/faucet/?id=e5d32df10aee11ec911142010a667c03) to receive the Test Token. If you have a large Test Token request, please send an email to support@latticex.foundation using the following format.
+Click [faucet](https://faucet.platon.network/faucet/) to receive the Test Token. If you have a large Test Token request, please send an email to support@latticex.foundation using the following format.
 ```
  Title: PlatON Development Network Token Request
  Your Name:

--- a/docs/网络说明.md
+++ b/docs/网络说明.md
@@ -24,7 +24,7 @@ If you want to connect to the development network as a validator, please refer t
 
 ## Development network faucet
 
-If you need to use test LAT on the development network, you have to obtain it through the faucet at <https://faucet.platon.network/faucet/?id=e5d32df10aee11ec911142010a667c03>
+If you need to use test LAT on the development network, you have to obtain it through the faucet at <https://faucet.platon.network/faucet/>
 
 > **Note**: LAT on the development network has no real value and is for testing only!
 

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/开发网水龙头.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/开发网水龙头.md
@@ -13,7 +13,7 @@ sidebar_label: 开发网水龙头
 
 2、如何申请测试币，申请测试LAT的规则
 
-​       PlatON开发网申请测试LAT，请进入水龙头链接：https://faucet.platon.network/faucet/?id=39fa041c887f11eba4f000163e06ae15。
+​       PlatON开发网申请测试LAT，请进入水龙头链接：https://faucet.platon.network/faucet/。
 
 ​       每个邮件地址每天限制领取200个测试LAT，若有大额测试LAT申请的需求，请参考下文。
 

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/接入开发网.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/接入开发网.md
@@ -49,7 +49,7 @@ curl -X POST -H 'content-type: application/json' --data '{"jsonrpc":"2.0","metho
 
 ### **第二步：在水龙头领取开发网测试Token**
 
-点击[水龙头](https://faucet.platon.network/faucet/?id=e5d32df10aee11ec911142010a667c03)领取测试Token。如果你有大额的测试Token需求，请用以下格式发送邮件到support@latticex.foundation：
+点击[水龙头](https://faucet.platon.network/faucet/)领取测试Token。如果你有大额的测试Token需求，请用以下格式发送邮件到support@latticex.foundation：
 ```
  标题：PlatON开发网Token申请
  姓名：

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/网络说明.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/网络说明.md
@@ -25,7 +25,7 @@ PlatON开发网络和主网功能一致，在版本上可能超前于主网。�
 
 #### 开发网络水龙头
 
-如果您有在开发网络上使用测试LAT的需求，您需要通过水龙头来领取，领取地址：<https://faucet.platon.network/faucet/?id=e5d32df10aee11ec911142010a667c03>
+如果您有在开发网络上使用测试LAT的需求，您需要通过水龙头来领取，领取地址：<https://faucet.platon.network/faucet/>
 
 > **提示**：开发网络上的LAT没有实际价值，仅用于测试使用！
 


### PR DESCRIPTION
更新开发网水龙头链接，链接更新为：https://faucet.platon.network/faucet/  .